### PR TITLE
Preserve classnames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test-compile:
 	babel --config-file=./tests/babel.config.json ./tests -x '.jsx' \
 		  --retain-lines -d ./tests-compiled --out-file-extension=.mjs
 
-test: test-compile
+test: test-compile test-mocha
 
 test-mocha:
 	mocha --require \"@babel/register\" 'tests-compiled/**/*.test.mjs'

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ test-compile:
 		  --retain-lines -d ./tests-compiled --out-file-extension=.mjs
 
 test: test-compile
+
+test-mocha:
 	mocha --require \"@babel/register\" 'tests-compiled/**/*.test.mjs'
 
 .PHONY: build dev

--- a/src/jsx-runtime/index.ts
+++ b/src/jsx-runtime/index.ts
@@ -114,6 +114,8 @@ jsx.renderDOM = (
       }
       // @ts-ignore
       elem[name] = attrVal
+      // @ts-ignore
+      elem[name.toLowerCase()] = attrVal
     })
 
   if (Array.isArray(node.props.children)) {

--- a/src/jsx-runtime/index.ts
+++ b/src/jsx-runtime/index.ts
@@ -35,7 +35,7 @@ function jsx (type: string | any, config: JSX.ElementChildrenAttribute): JSX.Ele
 
 jsx.Fragment = jsxFragment
 jsx.TextNode = jsxTextNode
-jsx.customAttributes = ['children', 'className', 'key', 'props']
+jsx.customAttributes = ['children', 'key', 'props']
 
 const isStandardAttribute = (key: string) => !jsx.customAttributes.includes(key)
 
@@ -100,7 +100,6 @@ jsx.renderDOM = (
   // classes
   if (props['className'] !== undefined) {
     props['class'] = props['className']
-    delete props['className']
   }
   if ((props['class'] !== undefined) && Array.isArray(props['class'])) {
     props['class'] = props['class'].join(' ')
@@ -118,7 +117,7 @@ jsx.renderDOM = (
         }
       }
       // @ts-ignore
-      elem[name.toLowerCase()] = attrVal
+      elem[name] = attrVal
     })
 
   if (Array.isArray(node.props.children)) {

--- a/src/jsx-runtime/index.ts
+++ b/src/jsx-runtime/index.ts
@@ -97,12 +97,8 @@ jsx.renderDOM = (
   const props = node.props
   const propKeys = Object.keys(props)
 
-  // classes
-  if (props['className'] !== undefined) {
-    props['class'] = props['className']
-  }
-  if ((props['class'] !== undefined) && Array.isArray(props['class'])) {
-    props['class'] = props['class'].join(' ')
+  if ((props['className'] !== undefined) && Array.isArray(props['className'])) {
+    props['className'] = props['className'].join(' ')
   }
 
   // assign attributes

--- a/tests/jsx-runtime.test.jsx
+++ b/tests/jsx-runtime.test.jsx
@@ -1,44 +1,80 @@
-import {expect} from 'chai'
-import {it} from 'mocha'
-import {Component} from '../src/jsx-runtime'
-import {createBlankPageCallback, h} from './helpers'
+import { expect } from "chai";
+import { it } from "mocha";
+import { Component } from "../src/jsx-runtime";
+import { createBlankPageCallback, h } from "./helpers";
 
-beforeEach(createBlankPageCallback)
+beforeEach(createBlankPageCallback);
 
-describe('suite name', () => {
-  it('div is NOT inserted in the dom', () => {
-    h(<div>test</div>)
-    expect(document.body.innerHTML).equals('')
-  })
-  it('div is inserted in the dom', () => {
-    h(<div>test</div>, document.body)
-    expect(document.body.innerHTML).equals('<div>test</div>')
-  })
-  it('component class is inserted in the dom', () => {
+describe("JSX Runtime", () => {
+  it("div is NOT inserted in the dom", () => {
+    h(<div>test</div>);
+    expect(document.body.innerHTML).equals("");
+  });
+
+  it("div is inserted in the dom", () => {
+    h(<div>test</div>, document.body);
+    expect(document.body.innerHTML).equals("<div>test</div>");
+  });
+
+  it("component class is inserted in the dom", () => {
     const onClickFn = (e) => {
-      console.log('button clicked', this, e)
-    }
+      console.log("button clicked", this, e);
+    };
 
     class PointInfo extends Component {
       constructor(props) {
-        super(props)
+        super(props);
       }
 
       render() {
-        const {x, y} = this.props
-        return (<div>
-          <span>{x} + {y}</span>
-          <button onClick={onClickFn}>Sub button</button>
-        </div>)
+        const { x, y } = this.props;
+        return (
+          <div>
+            <span>
+              {x} + {y}
+            </span>
+            <button onClick={onClickFn}>Sub button</button>
+          </div>
+        );
       }
     }
 
-    const elem = h(<PointInfo x={10} y={20}/>, document.body)
+    const elem = h(<PointInfo x={10} y={20} />, document.body);
     if (elem === null) {
-      throw new Error('elem is null')
+      throw new Error("elem is null");
     }
-    expect(elem).not.equals(null)
-    expect(document.body.innerHTML).equals('<div><span>10 + 20</span><button>Sub button</button></div>')
-//    expect(elem.childNodes[1].onclick).not(null) // .not(undefined)
-  })
-})
+    expect(elem).not.equals(null);
+    expect(document.body.innerHTML).equals(
+      "<div><span>10 + 20</span><button>Sub button</button></div>"
+    );
+  });
+
+  it("Preserves className for HTMLElements", () => {
+    const classNames = () => [
+      document.body.getElementsByClassName("outerDiv"),
+      document.body.getElementsByClassName("innerDiv"),
+      document.body.getElementsByClassName("text-node"),
+    ];
+
+    const assertClassNameExistences = (expectedAmount) =>
+      classNames().forEach((classNameList) =>
+        expect(classNameList.length).equals(expectedAmount)
+      );
+
+    const ExampleComponent = (_props = null) => (
+      <div className="outerDiv">
+        <div className="innerDiv">
+          <span className="text-node">className is useful</span>
+        </div>
+      </div>
+    );
+
+    // Before rendering, none of the classes should exist in the DOM
+    assertClassNameExistences(0);
+
+    h(<ExampleComponent />, document.body);
+
+    // After rendering, all classes should exist on exactly one element each
+    assertClassNameExistences(1);
+  });
+});


### PR DESCRIPTION
As [`class` is set by the `className` property][1], and not the `class` property itself, passing `className` through makes it so the rendered HTML keeps the `class`.

I don't know if this is the best way to go about this, but it works. :) 

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Element/className